### PR TITLE
PyInstaller

### DIFF
--- a/src/pyPolarionCli/__main__.py
+++ b/src/pyPolarionCli/__main__.py
@@ -38,9 +38,9 @@ import argparse
 import logging
 from polarion.polarion import Polarion
 
-from .version import __version__, __author__, __email__, __repository__, __license__
-from .ret import Ret
-from .cmd_search import register as cmd_search_register
+from pyPolarionCli.version import __version__, __author__, __email__, __repository__, __license__
+from pyPolarionCli.ret import Ret
+from pyPolarionCli.cmd_search import register as cmd_search_register
 
 
 ################################################################################

--- a/src/pyPolarionCli/cmd_search.py
+++ b/src/pyPolarionCli/cmd_search.py
@@ -40,7 +40,7 @@ from datetime import date, datetime
 from polarion.polarion import Polarion
 from polarion.project import Project
 from polarion.workitem import Workitem
-from .ret import Ret
+from pyPolarionCli.ret import Ret
 
 ################################################################################
 # Variables

--- a/tools/create_executable.bat
+++ b/tools/create_executable.bat
@@ -1,0 +1,2 @@
+rem Please run this script from the root path. ".\tools\create_executable.bat"
+pyinstaller --noconfirm --onefile --console --name "pyPolarionCli" --add-data "./pyproject.toml;."  "./src/pyPolarionCli/__main__.py"


### PR DESCRIPTION
Close #11 

Absolute imports must be used for executable to work.